### PR TITLE
fix: prevent concurrent session explosion and minor fixes

### DIFF
--- a/ida_mcp/proxy/ida_mcp_proxy.py
+++ b/ida_mcp/proxy/ida_mcp_proxy.py
@@ -55,6 +55,6 @@ if __name__ == "__main__":
         signal.signal(signal.SIGTERM, _signal_handler)
     
     try:
-        server.run()
+        server.run(show_banner=False)
     except KeyboardInterrupt:
         pass  # 静默退出


### PR DESCRIPTION
- Add _SessionStickyMiddleware in http_server.py to reuse MCP session ID across concurrent requests, preventing multiple session creation
- Captures session ID from first response, injects into subsequent requests
- Clears cached session on 404 (session terminated)
- Minor: add show_banner=False to proxy server run()