### PR TITLE
feat: add customizable timeout parameter to all proxy tools

### DIFF
--- a/ida_mcp/proxy/_http.py
+++ b/ida_mcp/proxy/_http.py
@@ -31,7 +31,7 @@ def http_get(path: str) -> Any:
         return None
 
 
-def http_post(path: str, obj: dict) -> Any:
+def http_post(path: str, obj: dict, timeout: int | None = None) -> Any:
     """POST 请求到协调器。"""
     data = json.dumps(obj).encode('utf-8')
     req = urllib.request.Request(
@@ -40,8 +40,9 @@ def http_post(path: str, obj: dict) -> Any:
         method='POST',
         headers={'Content-Type': 'application/json'}
     )
+    effective_timeout = timeout if timeout and timeout > 0 else REQUEST_TIMEOUT
     try:
-        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as r:
+        with urllib.request.urlopen(req, timeout=effective_timeout) as r:
             return json.loads(r.read().decode('utf-8') or 'null')
     except Exception as e:
         return {"error": str(e)}

--- a/ida_mcp/proxy/proxy_analysis.py
+++ b/ida_mcp/proxy/proxy_analysis.py
@@ -24,62 +24,69 @@ def register_tools(server: Any) -> None:
     def decompile(
         addr: Annotated[str, Field(description="Function address(es) or name(s), comma-separated")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """反编译函数。"""
-        return forward("decompile", {"addr": addr}, port)
+        return forward("decompile", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Disassemble function(s). addr can be address or name, comma-separated for batch.")
     def disasm(
         addr: Annotated[str, Field(description="Function address(es) or name(s), comma-separated")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """反汇编函数。"""
-        return forward("disasm", {"addr": addr}, port)
+        return forward("disasm", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Linear disassembly from address. Returns raw instructions.")
     def linear_disassemble(
         start_address: Annotated[str, Field(description="Start address")],
         count: Annotated[int, Field(description="Number of instructions")] = 20,
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """线性反汇编。"""
-        return forward("linear_disassemble", {"start_address": start_address, "count": count}, port)
+        return forward("linear_disassemble", {"start_address": start_address, "count": count}, port, timeout=timeout)
     
     @server.tool(description="Get cross-references TO address(es). addr comma-separated for batch.")
     def xrefs_to(
         addr: Annotated[str, Field(description="Target address(es), comma-separated")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """获取到地址的交叉引用。"""
-        return forward("xrefs_to", {"addr": addr}, port)
+        return forward("xrefs_to", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Get cross-references FROM address(es).")
     def xrefs_from(
         addr: Annotated[str, Field(description="Source address(es), comma-separated")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """获取从地址的交叉引用。"""
-        return forward("xrefs_from", {"addr": addr}, port)
+        return forward("xrefs_from", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Get cross-references to struct field. struct_name: type name, field_name: member name.")
     def xrefs_to_field(
         struct_name: Annotated[str, Field(description="Structure type name")],
         field_name: Annotated[str, Field(description="Field/member name")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """获取结构体字段的交叉引用。"""
         return forward("xrefs_to_field", {
             "struct_name": struct_name,
             "field_name": field_name
-        }, port)
+        }, port, timeout=timeout)
     
     @server.tool(description="Find function by name or address.")
     def get_function(
         query: Annotated[str, Field(description="Function name or address")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """查找函数。"""
-        return forward("get_function", {"query": query}, port)
+        return forward("get_function", {"query": query}, port, timeout=timeout)
     
     @server.tool(description="Search for byte pattern with wildcards (e.g. '48 8B ?? ?? 48 89').")
     def find_bytes(
@@ -88,6 +95,7 @@ def register_tools(server: Any) -> None:
         end: Annotated[Optional[str], Field(description="End address")] = None,
         limit: Annotated[int, Field(description="Max results")] = 100,
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """字节模式搜索。"""
         params: dict[str, Any] = {"pattern": pattern, "limit": limit}
@@ -95,12 +103,13 @@ def register_tools(server: Any) -> None:
             params["start"] = start
         if end:
             params["end"] = end
-        return forward("find_bytes", params, port)
+        return forward("find_bytes", params, port, timeout=timeout)
     
     @server.tool(description="Get basic blocks with control flow information.")
     def get_basic_blocks(
         addr: Annotated[str, Field(description="Function address or name")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """获取基本块。"""
-        return forward("get_basic_blocks", {"addr": addr}, port)
+        return forward("get_basic_blocks", {"addr": addr}, port, timeout=timeout)

--- a/ida_mcp/proxy/proxy_core.py
+++ b/ida_mcp/proxy/proxy_core.py
@@ -26,19 +26,21 @@ def register_tools(server: Any) -> None:
         count: Annotated[int, Field(description="Number of items")] = 100,
         pattern: Annotated[Optional[str], Field(description="Optional name filter")] = None,
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """列出函数。"""
         params: dict[str, Any] = {"offset": offset, "count": count}
         if pattern:
             params["pattern"] = pattern
-        return forward("list_functions", params, port)
+        return forward("list_functions", params, port, timeout=timeout)
     
     @server.tool(description="Get IDB metadata (input_file, arch, bits, hash, endian).")
     def get_metadata(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """获取 IDB 元数据。"""
-        return forward("get_metadata", {}, port)
+        return forward("get_metadata", {}, port, timeout=timeout)
     
     @server.tool(description="List strings. Params: offset, count, pattern (optional filter).")
     def list_strings(
@@ -46,12 +48,13 @@ def register_tools(server: Any) -> None:
         count: Annotated[int, Field(description="Number of items")] = 100,
         pattern: Annotated[Optional[str], Field(description="Optional content filter")] = None,
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """列出字符串。"""
         params: dict[str, Any] = {"offset": offset, "count": count}
         if pattern:
             params["pattern"] = pattern
-        return forward("list_strings", params, port)
+        return forward("list_strings", params, port, timeout=timeout)
     
     @server.tool(description="List global variables. Params: offset, count, pattern (optional filter).")
     def list_globals(
@@ -59,26 +62,29 @@ def register_tools(server: Any) -> None:
         count: Annotated[int, Field(description="Number of items")] = 100,
         pattern: Annotated[Optional[str], Field(description="Optional name filter")] = None,
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """列出全局变量。"""
         params: dict[str, Any] = {"offset": offset, "count": count}
         if pattern:
             params["pattern"] = pattern
-        return forward("list_globals", params, port)
+        return forward("list_globals", params, port, timeout=timeout)
     
     @server.tool(description="List local types defined in IDB.")
     def list_local_types(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """列出本地类型。"""
-        return forward("list_local_types", {}, port)
+        return forward("list_local_types", {}, port, timeout=timeout)
     
     @server.tool(description="Get entry points of the binary.")
     def get_entry_points(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """获取入口点。"""
-        return forward("get_entry_points", {}, port)
+        return forward("get_entry_points", {}, port, timeout=timeout)
     
     @server.tool(description="List imported functions with module names.")
     def list_imports(
@@ -86,12 +92,13 @@ def register_tools(server: Any) -> None:
         count: Annotated[int, Field(description="Number of items")] = 100,
         pattern: Annotated[Optional[str], Field(description="Optional name/module filter")] = None,
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """列出导入函数。"""
         params: dict[str, Any] = {"offset": offset, "count": count}
         if pattern:
             params["pattern"] = pattern
-        return forward("list_imports", params, port)
+        return forward("list_imports", params, port, timeout=timeout)
     
     @server.tool(description="List exported functions/symbols.")
     def list_exports(
@@ -99,23 +106,26 @@ def register_tools(server: Any) -> None:
         count: Annotated[int, Field(description="Number of items")] = 100,
         pattern: Annotated[Optional[str], Field(description="Optional name filter")] = None,
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """列出导出函数。"""
         params: dict[str, Any] = {"offset": offset, "count": count}
         if pattern:
             params["pattern"] = pattern
-        return forward("list_exports", params, port)
+        return forward("list_exports", params, port, timeout=timeout)
     
     @server.tool(description="List memory segments with permissions.")
     def list_segments(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """列出内存段。"""
-        return forward("list_segments", {}, port)
+        return forward("list_segments", {}, port, timeout=timeout)
     
     @server.tool(description="Get current cursor position and context in IDA.")
     def get_cursor(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """获取当前光标位置。"""
-        return forward("get_cursor", {}, port)
+        return forward("get_cursor", {}, port, timeout=timeout)

--- a/ida_mcp/proxy/proxy_debug.py
+++ b/ida_mcp/proxy/proxy_debug.py
@@ -23,105 +23,119 @@ def register_tools(server: Any) -> None:
     @server.tool(description="Start debugger process.")
     def dbg_start(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """启动调试器。"""
-        return forward("dbg_start", {}, port)
+        return forward("dbg_start", {}, port, timeout=timeout)
     
     @server.tool(description="Exit/terminate debugger process.")
     def dbg_exit(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """退出调试器。"""
-        return forward("dbg_exit", {}, port)
+        return forward("dbg_exit", {}, port, timeout=timeout)
     
     @server.tool(description="Continue debugger execution.")
     def dbg_continue(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """继续执行。"""
-        return forward("dbg_continue", {}, port)
+        return forward("dbg_continue", {}, port, timeout=timeout)
     
     @server.tool(description="Step into next instruction.")
     def dbg_step_into(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """单步进入。"""
-        return forward("dbg_step_into", {}, port)
+        return forward("dbg_step_into", {}, port, timeout=timeout)
     
     @server.tool(description="Step over next instruction.")
     def dbg_step_over(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """单步跳过。"""
-        return forward("dbg_step_over", {}, port)
+        return forward("dbg_step_over", {}, port, timeout=timeout)
     
     @server.tool(description="Run to address.")
     def dbg_run_to(
         addr: Annotated[str, Field(description="Target address")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """运行到指定地址。"""
-        return forward("dbg_run_to", {"addr": addr}, port)
+        return forward("dbg_run_to", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Get all CPU registers.")
     def dbg_regs(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """获取寄存器。"""
-        return forward("dbg_regs", {}, port)
+        return forward("dbg_regs", {}, port, timeout=timeout)
     
     @server.tool(description="Get call stack.")
     def dbg_callstack(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """获取调用栈。"""
-        return forward("dbg_callstack", {}, port)
+        return forward("dbg_callstack", {}, port, timeout=timeout)
     
     @server.tool(description="List all breakpoints.")
     def dbg_list_bps(
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """列出断点。"""
-        return forward("dbg_list_bps", {}, port)
+        return forward("dbg_list_bps", {}, port, timeout=timeout)
     
     @server.tool(description="Add breakpoint at address.")
     def dbg_add_bp(
         addr: Annotated[str, Field(description="Breakpoint address(es), comma-separated")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """设置断点。"""
-        return forward("dbg_add_bp", {"addr": addr}, port)
+        return forward("dbg_add_bp", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Delete breakpoint at address.")
     def dbg_delete_bp(
         addr: Annotated[str, Field(description="Breakpoint address(es), comma-separated")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """删除断点。"""
-        return forward("dbg_delete_bp", {"addr": addr}, port)
+        return forward("dbg_delete_bp", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Enable or disable breakpoint.")
     def dbg_enable_bp(
         items: Annotated[list, Field(description="List of {address, enable} objects")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """启用/禁用断点。"""
-        return forward("dbg_enable_bp", {"items": items}, port)
+        return forward("dbg_enable_bp", {"items": items}, port, timeout=timeout)
     
     @server.tool(description="Read memory in debugger.")
     def dbg_read_mem(
         addr: Annotated[str, Field(description="Memory address")],
         size: Annotated[int, Field(description="Bytes to read")] = 64,
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """调试器读取内存。"""
-        return forward("dbg_read_mem", {"addr": addr, "size": size}, port)
+        return forward("dbg_read_mem", {"addr": addr, "size": size}, port, timeout=timeout)
     
     @server.tool(description="Write memory in debugger.")
     def dbg_write_mem(
         addr: Annotated[str, Field(description="Memory address")],
         data: Annotated[str, Field(description="Hex string to write")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """调试器写入内存。"""
-        return forward("dbg_write_mem", {"addr": addr, "data": data}, port)
+        return forward("dbg_write_mem", {"addr": addr, "data": data}, port, timeout=timeout)

--- a/ida_mcp/proxy/proxy_memory.py
+++ b/ida_mcp/proxy/proxy_memory.py
@@ -25,47 +25,53 @@ def register_tools(server: Any) -> None:
         addr: Annotated[str, Field(description="Memory address(es), comma-separated")],
         size: Annotated[int, Field(description="Bytes to read (1-4096)")] = 64,
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """读取内存字节。"""
-        return forward("get_bytes", {"addr": addr, "size": size}, port)
+        return forward("get_bytes", {"addr": addr, "size": size}, port, timeout=timeout)
     
     @server.tool(description="Read 8-bit unsigned integer from address.")
     def get_u8(
         addr: Annotated[str, Field(description="Memory address(es), comma-separated")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """读取 8 位无符号整数。"""
-        return forward("get_u8", {"addr": addr}, port)
+        return forward("get_u8", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Read 16-bit unsigned integer from address.")
     def get_u16(
         addr: Annotated[str, Field(description="Memory address(es), comma-separated")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """读取 16 位无符号整数。"""
-        return forward("get_u16", {"addr": addr}, port)
+        return forward("get_u16", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Read 32-bit unsigned integer from address.")
     def get_u32(
         addr: Annotated[str, Field(description="Memory address(es), comma-separated")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """读取 32 位无符号整数。"""
-        return forward("get_u32", {"addr": addr}, port)
+        return forward("get_u32", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Read 64-bit unsigned integer from address.")
     def get_u64(
         addr: Annotated[str, Field(description="Memory address(es), comma-separated")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """读取 64 位无符号整数。"""
-        return forward("get_u64", {"addr": addr}, port)
+        return forward("get_u64", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Read null-terminated string from address.")
     def get_string(
         addr: Annotated[str, Field(description="Memory address(es), comma-separated")],
         max_len: Annotated[int, Field(description="Maximum length")] = 256,
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """读取字符串。"""
-        return forward("get_string", {"addr": addr, "max_len": max_len}, port)
+        return forward("get_string", {"addr": addr, "max_len": max_len}, port, timeout=timeout)

--- a/ida_mcp/proxy/proxy_modify.py
+++ b/ida_mcp/proxy/proxy_modify.py
@@ -24,33 +24,36 @@ def register_tools(server: Any) -> None:
     def set_comment(
         items: Annotated[list, Field(description="List of {address, comment} objects")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """设置注释。"""
-        return forward("set_comment", {"items": items}, port)
+        return forward("set_comment", {"items": items}, port, timeout=timeout)
     
     @server.tool(description="Rename a function.")
     def rename_function(
         address: Annotated[str, Field(description="Function address or name")],
         new_name: Annotated[str, Field(description="New function name")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """重命名函数。"""
         return forward("rename_function", {
             "function_address": address,
             "new_name": new_name
-        }, port)
+        }, port, timeout=timeout)
     
     @server.tool(description="Rename a global variable.")
     def rename_global_variable(
         old_name: Annotated[str, Field(description="Current variable name")],
         new_name: Annotated[str, Field(description="New variable name")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """重命名全局变量。"""
         return forward("rename_global_variable", {
             "old_name": old_name,
             "new_name": new_name
-        }, port)
+        }, port, timeout=timeout)
     
     @server.tool(description="Rename a local variable in a function.")
     def rename_local_variable(
@@ -58,18 +61,20 @@ def register_tools(server: Any) -> None:
         old_name: Annotated[str, Field(description="Current variable name")],
         new_name: Annotated[str, Field(description="New variable name")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """重命名局部变量。"""
         return forward("rename_local_variable", {
             "function_address": function_address,
             "old_name": old_name,
             "new_name": new_name
-        }, port)
+        }, port, timeout=timeout)
     
     @server.tool(description="Patch bytes at address(es). items: [{address, bytes: [int,...] or hex_string}].")
     def patch_bytes(
         items: Annotated[list, Field(description="List of {address, bytes} objects")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """字节补丁。"""
-        return forward("patch_bytes", {"items": items}, port)
+        return forward("patch_bytes", {"items": items}, port, timeout=timeout)

--- a/ida_mcp/proxy/proxy_stack.py
+++ b/ida_mcp/proxy/proxy_stack.py
@@ -24,23 +24,26 @@ def register_tools(server: Any) -> None:
     def stack_frame(
         addr: Annotated[str, Field(description="Function address(es) or name(s), comma-separated")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """获取栈帧变量。"""
-        return forward("stack_frame", {"addr": addr}, port)
+        return forward("stack_frame", {"addr": addr}, port, timeout=timeout)
     
     @server.tool(description="Declare stack variable(s). items: [{function_address, offset, name, type?, size?}].")
     def declare_stack(
         items: Annotated[List[Dict[str, Any]], Field(description="List of stack variable definitions")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """声明栈变量。"""
-        return forward("declare_stack", {"items": items}, port)
+        return forward("declare_stack", {"items": items}, port, timeout=timeout)
     
     @server.tool(description="Delete stack variable(s). items: [{function_address, name}].")
     def delete_stack(
         items: Annotated[List[Dict[str, Any]], Field(description="List of {function_address, name}")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """删除栈变量。"""
-        return forward("delete_stack", {"items": items}, port)
+        return forward("delete_stack", {"items": items}, port, timeout=timeout)
 

--- a/ida_mcp/proxy/proxy_types.py
+++ b/ida_mcp/proxy/proxy_types.py
@@ -25,12 +25,13 @@ def register_tools(server: Any) -> None:
         function_address: Annotated[str, Field(description="Function address")],
         prototype: Annotated[str, Field(description="C-style function prototype")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """设置函数原型。"""
         return forward("set_function_prototype", {
             "function_address": function_address,
             "prototype": prototype
-        }, port)
+        }, port, timeout=timeout)
     
     @server.tool(description="Set type of a local variable.")
     def set_local_variable_type(
@@ -38,49 +39,54 @@ def register_tools(server: Any) -> None:
         variable_name: Annotated[str, Field(description="Variable name")],
         new_type: Annotated[str, Field(description="C-style type declaration")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """设置局部变量类型。"""
         return forward("set_local_variable_type", {
             "function_address": function_address,
             "variable_name": variable_name,
             "new_type": new_type
-        }, port)
+        }, port, timeout=timeout)
     
     @server.tool(description="Set type of a global variable.")
     def set_global_variable_type(
         variable_name: Annotated[str, Field(description="Global variable name")],
         new_type: Annotated[str, Field(description="C-style type declaration")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """设置全局变量类型。"""
         return forward("set_global_variable_type", {
             "variable_name": variable_name,
             "new_type": new_type
-        }, port)
+        }, port, timeout=timeout)
     
     @server.tool(description="Declare a new C type (struct, enum, typedef).")
     def declare_type(
         decl: Annotated[str, Field(description="C-style type declaration")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """声明新类型。"""
-        return forward("declare_type", {"decl": decl}, port)
+        return forward("declare_type", {"decl": decl}, port, timeout=timeout)
     
     @server.tool(description="List all structures/unions defined in the database.")
     def list_structs(
         pattern: Annotated[Optional[str], Field(description="Optional name filter")] = None,
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """列出结构体。"""
         params: dict[str, Any] = {}
         if pattern:
             params["pattern"] = pattern
-        return forward("list_structs", params, port)
+        return forward("list_structs", params, port, timeout=timeout)
     
     @server.tool(description="Get detailed structure/union definition with fields.")
     def get_struct_info(
         name: Annotated[str, Field(description="Structure/union name")],
         port: Annotated[Optional[int], Field(description="Instance port override")] = None,
+        timeout: Annotated[Optional[int], Field(description="Timeout in seconds")] = None,
     ) -> Any:
         """获取结构体详情。"""
-        return forward("get_struct_info", {"name": name}, port)
+        return forward("get_struct_info", {"name": name}, port, timeout=timeout)


### PR DESCRIPTION
- http_post() accepts optional timeout parameter
- forward() passes timeout to request body (for coordinator) and http_post
- HTTP layer timeout = tool timeout + 15s buffer to prevent premature disconnect
- registry.py /call handler reads timeout from request body for Client and lock
- Added try/except safety for non-numeric timeout values
- All 8 proxy modules updated: timeout param added to every tool definition
- Default behavior unchanged when timeout is not specified